### PR TITLE
Force the LBAPI responses to be treated as UTF-8

### DIFF
--- a/src/test/java/com/rallydev/lookback/LookbackIntegrationTest.java
+++ b/src/test/java/com/rallydev/lookback/LookbackIntegrationTest.java
@@ -1,5 +1,13 @@
 package com.rallydev.lookback;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -9,14 +17,6 @@ import org.simpleframework.http.Response;
 import org.simpleframework.http.core.Container;
 import org.simpleframework.http.core.ContainerServer;
 import org.simpleframework.transport.connect.SocketConnection;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Stack;
 
 public class LookbackIntegrationTest {
 
@@ -129,7 +129,7 @@ public class LookbackIntegrationTest {
         try {
             InputStream is = getClass().getResource("/1.json").openStream();
             Assert.assertNotNull(is);
-            json = IOUtils.toString(is);
+            json = IOUtils.toString(is, "UTF-8");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/src/test/java/com/rallydev/lookback/ProxiedLookbackApiTest.java
+++ b/src/test/java/com/rallydev/lookback/ProxiedLookbackApiTest.java
@@ -1,5 +1,8 @@
 package com.rallydev.lookback;
 
+import java.io.InputStream;
+import java.util.Stack;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -9,9 +12,6 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 import org.simpleframework.http.core.Container;
-
-import java.io.InputStream;
-import java.util.Stack;
 
 public class ProxiedLookbackApiTest extends LookbackIntegrationTest {
 
@@ -53,6 +53,8 @@ public class ProxiedLookbackApiTest extends LookbackIntegrationTest {
                 .execute();
 
         Assert.assertEquals("there should be 2 results", 2, result.Results.size());
+        Assert.assertEquals("Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa", result.Results.get(0).get("Name"));
+
     }
 
 
@@ -74,6 +76,7 @@ public class ProxiedLookbackApiTest extends LookbackIntegrationTest {
         ret = capturesRequest(ret);
         ret = respondWith(ret, 407);
         ret = addsHeader(ret, "Proxy-Authenticate", "Basic realm=\"theproxy\"");
+        ret = addsHeader(ret, "Content-Type", "application/json; charset=UTF-8");
         return ret;
     }
 
@@ -91,6 +94,7 @@ public class ProxiedLookbackApiTest extends LookbackIntegrationTest {
         ret = capturesRequest(ret);
         ret = assertsHeader(ret, "Proxy-Authorization", "Basic dGVzdDpwYXNz");
         ret = assertsHeader(ret, "Authorization", "Basic dGVzdDE6cGFzczE=");
+        ret = addsHeader(ret, "Content-Type", "application/json; charset=UTF-8");
         return ret;
     }
 
@@ -99,6 +103,7 @@ public class ProxiedLookbackApiTest extends LookbackIntegrationTest {
         ret = capturesRequest(ret);
         ret = assertsHeader(ret, "Proxy-Authorization", "Basic dGVzdDpwYXNz");
         ret = addsHeader(ret, "WWW-Authenticate", "Basic realm=\"myRealm\"");
+        ret = addsHeader(ret, "Content-Type", "application/json; charset=UTF-8");
         ret = respondWith(ret, 401);
         return ret;
     }

--- a/src/test/resources/1.json
+++ b/src/test/resources/1.json
@@ -44,7 +44,7 @@
     "PageSize": 100,
     "ETLDate": "2014-08-20T18:29:22.379Z",
     "Results": [
-        {"ObjectID":5.387234184E9,"Project":2.79050021E8,"_ValidFrom":"2012-02-08T14:42:14.147Z","_ValidTo":"2012-02-09T19:16:26.890Z","_id":"53e110d3e4b03369a36c47e1"},
-        {"ObjectID":4.9413018E9,"Project":2.79050021E8,"_ValidFrom":"2012-02-08T14:13:16.509Z","_ValidTo":"2012-02-08T14:13:20.022Z","_id":"53e110d3e4b03369a36c47c1"}
+        {"ObjectID":5.387234184E9,"Name":"Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa","Project":2.79050021E8,"_ValidFrom":"2012-02-08T14:42:14.147Z","_ValidTo":"2012-02-09T19:16:26.890Z","_id":"53e110d3e4b03369a36c47e1"},
+        {"ObjectID":4.9413018E9,"Name":"Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa","Project":2.79050021E8,"_ValidFrom":"2012-02-08T14:13:16.509Z","_ValidTo":"2012-02-08T14:13:20.022Z","_id":"53e110d3e4b03369a36c47c1"}
      ]
 }


### PR DESCRIPTION
Currently, the string handling within the toolkit leaves string encoding
up to the platform which is often wrong.  

The updated code forces the response handling to treat the incoming
response body as a UTF-8 encoded stream before handing off to GSON to
deserialize.

Updated the integration test to include a name that contains unicode
characters and compares the result.
